### PR TITLE
fix: chat input container visibility, adding margin bottom

### DIFF
--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -56,6 +56,7 @@ h1, h2 {
 .url-input-container, .chat-input-container {
     display: flex;
     gap: 10px;
+    margin-bottom: 40px;
 }
 
 #agent-url, #chat-input {
@@ -155,7 +156,7 @@ h1, h2 {
     bottom: 0;
     left: 0;
     width: 100%;
-    height: 300px; 
+    height: 300px;
     background: #2f3640;
     color: #f5f6fa;
     box-shadow: 0 -2px 10px rgba(0,0,0,0.2);


### PR DESCRIPTION
# Description

I found a small issue with the chat input container visibility. Please see screenshots below:

![Screenshot 2025-06-18 at 18 23 15](https://github.com/user-attachments/assets/2ec25a2d-8a2f-4a11-9622-d2f4856b2e02)

Adding a margin-bottom fixes it

![Screenshot 2025-06-18 at 18 23 23](https://github.com/user-attachments/assets/8aae2816-cb5f-4594-b50d-82676975f8af)

---

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)
