### PR TITLE
fix(frontend): Add timeout for client initialization

### DIFF
--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -93,6 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const rawLogStore: Record<string, Record<string, any>> = {};
   const messageJsonStore: {[key: string]: AgentResponseEvent} = {};
+  let initializationTimeout: NodeJS.Timeout;
 
   debugHandle.addEventListener('mousedown', (e: MouseEvent) => {
     const target = e.target as HTMLElement;
@@ -257,6 +258,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
       validationErrorsContainer.innerHTML =
         '<p class="placeholder-text">Initializing client session...</p>';
+
+      initializationTimeout = setTimeout(() => {
+        validationErrorsContainer.innerHTML = `<p style="color: red;">Error: Client initialization timed out.</p>`;
+        chatInput.disabled = true;
+        sendBtn.disabled = true;
+      }, 10000); 
+
       socket.emit('initialize_client', {
         url: agentCardUrl,
         customHeaders: customHeaders,
@@ -269,6 +277,7 @@ document.addEventListener('DOMContentLoaded', () => {
           '<p style="color: green;">Agent card is valid.</p>';
       }
     } catch (error) {
+      clearTimeout(initializationTimeout);
       validationErrorsContainer.innerHTML = `<p style="color: red;">Error: ${(error as Error).message}</p>`;
       chatInput.disabled = true;
       sendBtn.disabled = true;
@@ -278,6 +287,7 @@ document.addEventListener('DOMContentLoaded', () => {
   socket.on(
     'client_initialized',
     (data: {status: string; message?: string}) => {
+      clearTimeout(initializationTimeout);
       if (data.status === 'success') {
         chatInput.disabled = false;
         sendBtn.disabled = false;


### PR DESCRIPTION
# Description
The socket.emit('initialize_client') call in frontend/src/script.ts did not have a timeout. If the backend failed to respond with a client_initialized event, the user interface would remain in an "Initializing..." state indefinitely. This could happen during backend failures, high load, or network connectivity issues, leading to a poor user experience.

This fix implements a 10-second timeout for the initialization. If the backend does not respond within this period, a clear error message is displayed to the user.

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
