### PR TITLE
fix(frontend): Fix TypeScript error for setTimeout return type

### DIFF
--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -95,7 +95,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const rawLogStore: Record<string, Record<string, any>> = {};
   const messageJsonStore: {[key: string]: AgentResponseEvent} = {};
-  let initializationTimeout: number;
+  let initializationTimeout: NodeJS.Timeout;
 
   debugHandle.addEventListener('mousedown', (e: MouseEvent) => {
     const target = e.target as HTMLElement;

--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -95,7 +95,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const rawLogStore: Record<string, Record<string, any>> = {};
   const messageJsonStore: {[key: string]: AgentResponseEvent} = {};
-  let initializationTimeout: NodeJS.Timeout;
+  let initializationTimeout: ReturnType<typeof setTimeout>;
 
   debugHandle.addEventListener('mousedown', (e: MouseEvent) => {
     const target = e.target as HTMLElement;


### PR DESCRIPTION
## Summary
- Fixes TypeScript compilation error in `frontend/src/script.ts:264`
- Changes `initializationTimeout` type from `number` to `NodeJS.Timeout` to match `setTimeout` return type

## Problem
The code was failing TypeScript compilation with error:
```
Type 'Timeout' is not assignable to type 'number'
```

## Solution
Updated the type declaration on line 98 to use `NodeJS.Timeout` which is the correct return type for `setTimeout` in Node.js environments.

## Test plan
- [x] TypeScript compilation now passes without errors
- [x] No functional changes - purely a type fix

🤖 Generated with [Claude Code](https://claude.ai/code)