### PR TITLE
fix: Docker build fails on mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN npm ci
 COPY frontend/ ./
 
 # Rebuild native dependencies like esbuild for the container's architecture (Alpine)
-# in case host node_modules were copied over.RUN 
+# in case host node_modules were copied over.
 RUN npm rebuild esbuild
 
 RUN npm run build


### PR DESCRIPTION
# Description

This PR aims to fix the docker build issue on mac OS, utilizing the feedback provided by @hironow .

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

Fixes #39  🦕
