### PR TITLE
feat: Add robust url validation

### DIFF
--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -228,11 +228,15 @@ document.addEventListener('DOMContentLoaded', () => {
       agentCardUrl = 'http://' + agentCardUrl;
     }
 
+    // Validate that the URL uses http or https protocol
     try {
-      new URL(agentCardUrl);
+      const url = new URL(agentCardUrl);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        throw new Error('Protocol must be http or https.');
+      }
     } catch (error) {
       alert(
-        'Invalid URL. Please enter a complete and valid URL (e.g., http://example.com).',
+        'Invalid URL. Please enter a valid URL starting with http:// or https://.',
       );
       return;
     }

--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -229,7 +229,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     try {
-      new URL(agentCardUrl);
+      const parsedUrl = new URL(agentCardUrl);
+      if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+        throw new Error('Unsupported protocol');
+      }
     } catch (error) {
       alert(
         'Invalid URL. Please enter a complete and valid URL (e.g., http://example.com).',

--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -229,10 +229,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     try {
-      const parsedUrl = new URL(agentCardUrl);
-      if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
-        throw new Error('Unsupported protocol');
-      }
+      new URL(agentCardUrl);
     } catch (error) {
       alert(
         'Invalid URL. Please enter a complete and valid URL (e.g., http://example.com).',

--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -219,10 +219,22 @@ document.addEventListener('DOMContentLoaded', () => {
   connectBtn.addEventListener('click', async () => {
     let agentCardUrl = agentCardUrlInput.value.trim();
     if (!agentCardUrl) {
-      return alert('Please enter an agent card URL.');
+      alert('Please enter an agent card URL.');
+      return;
     }
-    if (!/^https?:\/\//i.test(agentCardUrl)) {
+
+    // If no protocol is specified, prepend http://
+    if (!/^[a-zA-Z]+:\/\//.test(agentCardUrl)) {
       agentCardUrl = 'http://' + agentCardUrl;
+    }
+
+    try {
+      new URL(agentCardUrl);
+    } catch (error) {
+      alert(
+        'Invalid URL. Please enter a complete and valid URL (e.g., http://example.com).',
+      );
+      return;
     }
 
     agentCardCodeContent.textContent = '';


### PR DESCRIPTION
# Description

This update addresses an issue where the frontend was not properly validating the Agent Card URL, which could lead to malformed URLs being sent to the backend.

**Before this change:**
Entering `ftp://example.com` would result in the application trying to fetch `http://ftp://example.com`, which is an invalid URL.
<img width="898" height="449" alt="Screenshot from 2025-07-20 18-38-39" src="https://github.com/user-attachments/assets/dcc4bd61-69ce-462d-a3bc-3ab6627d89cd" />


**After this change:**

The code now uses the `URL` constructor to validate the URL.
**Invalid URL (Incorrect Protocol):**
Enter a URL with an unsupported protocol, such as ftp://example.com.
**Expected behavior:** An alert should appear with an error message like "Invalid URL. Please enter a complete and valid URL (e.g., http://example.com/)." The application should not attempt to connect.
  
<img width="788" height="314" alt="image" src="https://github.com/user-attachments/assets/160482c6-4d66-43e2-af07-f66e414d9133" />

**Malformed URL:**
Enter a malformed URL, such as google.com:badport.
**Expected behavior:** You should see the same "Invalid URL" alert, and no connection attempt should be made.
<img width="911" height="432" alt="Screenshot from 2025-07-20 18-35-48" src="https://github.com/user-attachments/assets/27fe4085-778d-4adb-ad20-8aca9c69bdd8" />
