### PR TITLE
fix: make agent card scrollable for long inputs

### DIFF
--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -41,7 +41,7 @@ h2 {
 
 .collapsible-content {
     max-height: 1000px;
-    overflow: hidden;
+    overflow-y: auto;
     transition: max-height 0.3s ease-in-out;
 }
 
@@ -160,7 +160,8 @@ h2 {
     border-radius: 4px;
     white-space: pre-wrap;
     word-wrap: break-word;
-    overflow-x: auto;
+    max-height: 400px;
+    overflow: auto;
 }
 
 .message {


### PR DESCRIPTION
# Description
While using the A2A inspector I noticed you are unable to scroll to see the rest of a long agent card.
**Note that in the before the rest of the card is truncated with no way to scroll to see the rest.**

<table>
  <tr>
    <th align="center">Before</th>
    <th align="center">After</th>
  </tr>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/efa3f0ad-e52b-4947-a300-c08f9f3e639b" width="400" alt="Before (truncated card)">
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/1953254e-031c-44e5-b7f8-8507b118b179" width="400" alt="After (scrollable card)">
    </td>
  </tr>
</table>




Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)
