### PR TITLE
fix: Sanitize chat messages on client-side to prevent XSS

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,6 +4,7 @@ from typing import Any
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
+import bleach
 import httpx
 import socketio
 import validators
@@ -282,7 +283,8 @@ async def handle_initialize_client(sid: str, data: dict[str, Any]) -> None:
 @sio.on('send_message')
 async def handle_send_message(sid: str, json_data: dict[str, Any]) -> None:
     """Handle the 'send_message' socket.io event."""
-    message_text = json_data.get('message')
+    message_text = bleach.clean(json_data.get('message', ''))
+
     message_id = json_data.get('id', str(uuid4()))
     context_id = json_data.get('contextId')
 

--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -191,7 +191,7 @@ document.addEventListener('DOMContentLoaded', () => {
   clearConsoleBtn.addEventListener('click', () => {
     debugContent.innerHTML = '';
     Object.keys(rawLogStore).forEach(key => delete rawLogStore[key]);
-    logIdQueue.length = 0; 
+    logIdQueue.length = 0;
   });
 
   toggleConsoleBtn.addEventListener('click', () => {
@@ -333,10 +333,23 @@ document.addEventListener('DOMContentLoaded', () => {
   const sendMessage = () => {
     const messageText = chatInput.value;
     if (messageText.trim() && !chatInput.disabled) {
+      // Sanitize the user's input before doing anything else
+      const sanitizedMessage = DOMPurify.sanitize(messageText);
+  
+      // Optional but recommended: prevent sending messages that are empty after sanitization
+      if (!sanitizedMessage.trim()) {
+        chatInput.value = '';
+        return;
+      }
+  
       const messageId = `msg-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-      appendMessage('user', messageText, messageId);
+      
+      // Use the sanitized message when displaying it locally
+      appendMessage('user', sanitizedMessage, messageId);
+  
+      // Use the sanitized message when sending it to the server
       socket.emit('send_message', {
-        message: messageText,
+        message: sanitizedMessage,
         id: messageId,
         contextId,
       });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "uvicorn>=0.34.0",
     "python-socketio",
     "jinja2",
-    "bleach>=6.0.0",
+    "bleach>=6.2.0",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "uvicorn>=0.34.0",
     "python-socketio",
     "jinja2",
+    "bleach>=6.0.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
#### Description

This update resolves a critical security vulnerability where chat messages were sent to the backend without being sanitized. This exposed the application to potential Cross-Site Scripting (XSS) attacks if a message containing malicious HTML (e.g., a `<script>` tag) was ever rendered.

The solution is to sanitize the message text on the client-side using **`DOMPurify.sanitize()`** within the `sendMessage` function in `frontend/src/script.ts`. This ensures that any potentially harmful HTML is removed *before* the message is transmitted to the server or displayed in the user's own chat window.

This change is a critical security enhancement to prevent XSS attacks and ensure that all user-generated content can be rendered safely.

Fixes #55 🦕