### PR TITLE
feat: multi-turn conversations support

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -287,6 +287,7 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> None:
 
     message_id = json_data.get('id', str(uuid4()))
     context_id = json_data.get('contextId')
+    task_id = json_data.get('taskId')
 
     if sid not in clients:
         await sio.emit(
@@ -303,6 +304,7 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> None:
         parts=[TextPart(text=str(message_text))],  # type: ignore[list-item]
         message_id=message_id,
         context_id=context_id,
+        task_id=task_id,
     )
     payload = MessageSendParams(
         message=message,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "esbuild src/script.ts --bundle --outfile=public/script.js --platform=browser",
+    "dev": "esbuild src/script.ts --bundle --outfile=public/script.js --platform=browser --sourcemap",
     "lint": "gts lint",
     "clean": "gts clean",
     "compile": "tsc",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -54,6 +54,10 @@
             <div class="chat-input-container">
                 <input type="text" id="chat-input" placeholder="Type a message..." disabled>
                 <button id="send-btn" disabled>Send</button>
+                <label id="use-taskid-label" style="display:none; align-items:center; gap:4px; margin-left:10px; font-size:0.95em;">
+                  <input type="checkbox" id="use-taskid-checkbox" disabled>
+                  use previous task_id
+                </label>
             </div>
         </div>
     </div>

--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -75,6 +75,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const chatInput = document.getElementById('chat-input') as HTMLInputElement;
   const sendBtn = document.getElementById('send-btn') as HTMLButtonElement;
   const chatMessages = document.getElementById('chat-messages') as HTMLElement;
+  const useTaskIdCheckbox = document.getElementById(
+    'use-taskid-checkbox',
+  ) as HTMLInputElement;
+  const useTaskIdLabel = document.getElementById(
+    'use-taskid-label',
+  ) as HTMLLabelElement;
   const debugConsole = document.getElementById('debug-console') as HTMLElement;
   const debugHandle = document.getElementById('debug-handle') as HTMLElement;
   const debugContent = document.getElementById('debug-content') as HTMLElement;
@@ -128,7 +134,7 @@ document.addEventListener('DOMContentLoaded', () => {
     collapsibleContent.classList.toggle('collapsed');
     collapsibleContent.style.overflow = 'hidden';
   });
-  
+
   collapsibleContent.addEventListener('transitionend', () => {
     if (!collapsibleContent.classList.contains('collapsed')) {
       collapsibleContent.style.overflow = 'auto';
@@ -258,6 +264,17 @@ document.addEventListener('DOMContentLoaded', () => {
     chatInput.disabled = true;
     sendBtn.disabled = true;
 
+    // Hide and disable the use-taskid checkbox and clear chat messages
+    if (useTaskIdLabel && useTaskIdCheckbox) {
+      useTaskIdLabel.style.display = 'none';
+      useTaskIdCheckbox.disabled = true;
+      useTaskIdCheckbox.checked = false;
+    }
+    if (chatMessages) {
+      chatMessages.innerHTML =
+        '<p class="placeholder-text">Messages will appear here.</p>';
+    }
+
     // Get custom headers
     const customHeaders = getCustomHeaders();
 
@@ -336,30 +353,37 @@ document.addEventListener('DOMContentLoaded', () => {
   );
 
   let contextId: string | null = null;
+  let previousTaskId: string | null = null;
 
   const sendMessage = () => {
     const messageText = chatInput.value;
     if (messageText.trim() && !chatInput.disabled) {
       // Sanitize the user's input before doing anything else
       const sanitizedMessage = DOMPurify.sanitize(messageText);
-  
+
       // Optional but recommended: prevent sending messages that are empty after sanitization
       if (!sanitizedMessage.trim()) {
         chatInput.value = '';
         return;
       }
-  
+
       const messageId = `msg-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-      
+
       // Use the sanitized message when displaying it locally
       appendMessage('user', sanitizedMessage, messageId);
-  
-      // Use the sanitized message when sending it to the server
-      socket.emit('send_message', {
+
+      // Prepare payload
+      const payload: Record<string, unknown> = {
         message: sanitizedMessage,
         id: messageId,
         contextId,
-      });
+      };
+      if (useTaskIdCheckbox && useTaskIdCheckbox.checked && previousTaskId) {
+        payload.taskId = previousTaskId;
+      }
+
+      // Use the sanitized message when sending it to the server
+      socket.emit('send_message', payload);
       chatInput.value = '';
     }
   };
@@ -372,6 +396,17 @@ document.addEventListener('DOMContentLoaded', () => {
   socket.on('agent_response', (event: AgentResponseEvent) => {
     const displayMessageId = `display-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     messageJsonStore[displayMessageId] = event;
+
+    // Show and enable the use-taskid checkbox if a response is received
+    if (useTaskIdLabel && useTaskIdCheckbox) {
+      useTaskIdLabel.style.display = '';
+      useTaskIdCheckbox.disabled = false;
+    }
+
+    // Store previous task_id if present
+    if ((event as AgentResponseEvent).id && event.kind === 'task') {
+      previousTaskId = (event as AgentResponseEvent).id;
+    }
 
     const validationErrors = event.validation_errors || [];
 


### PR DESCRIPTION
Add support for multi-turn conversations:

1. Add a checkbox to the chat section:
    1. Initially hidden
    2. When new message arrive with a `taskId`, enabled
    3. When checked, will send the last `taskId` along with new messages
1. In the backend, read the `taskId` and pass it on in the a2a message to the server.

Fixes #63 🦕
