### PR TITLE
fix(deps): Add missing `fastapi` dependency to resolve Docker startup failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "a2a-sdk>=0.3.0",
+    "fastapi[standard]",
     "httpx>=0.28.1",
     "httpx-sse>=0.4.0",
     "jwcrypto>=1.5.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "a2a-sdk>=0.3.0",
-    "fastapi[standard]",
+    "a2a-sdk[http-server]>=0.3.0",
     "httpx>=0.28.1",
     "httpx-sse>=0.4.0",
     "jwcrypto>=1.5.6",


### PR DESCRIPTION
# Description
The Docker container was failing to start with 'ModuleNotFoundError: No module named fastapi'. This adds fastapi[standard] to the project dependencies in pyproject.toml to fix the issue.

Fixes #82 🦕
