### PR TITLE
feat: Add support for metadata value dict parsing

### DIFF
--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -1,5 +1,5 @@
-import {io} from 'socket.io-client';
-import {marked} from 'marked';
+import { io } from 'socket.io-client';
+import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 
 // A2A File types (matching spec)
@@ -27,10 +27,10 @@ interface AgentResponseEvent {
   error?: string;
   status?: {
     state: string;
-    message?: {parts?: {text?: string}[]};
+    message?: { parts?: { text?: string }[] };
   };
   artifact?: {
-    parts?: ({file?: FileContent} | {text?: string} | {data?: object})[];
+    parts?: ({ file?: FileContent } | { text?: string } | { data?: object })[];
   };
   artifacts?: Array<{
     artifactId?: string;
@@ -38,12 +38,12 @@ interface AgentResponseEvent {
     description?: string;
     metadata?: object;
     parts?: (
-      | {kind?: string; file?: FileContent}
-      | {kind?: string; text?: string}
-      | {kind?: string; data?: object}
+      | { kind?: string; file?: FileContent }
+      | { kind?: string; text?: string }
+      | { kind?: string; data?: object }
     )[];
   }>;
-  parts?: {text?: string}[];
+  parts?: { text?: string }[];
   validation_errors: string[];
 }
 
@@ -174,7 +174,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let isResizing = false;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const rawLogStore: Record<string, Record<string, any>> = {};
-  const messageJsonStore: {[key: string]: AgentResponseEvent} = {};
+  const messageJsonStore: { [key: string]: AgentResponseEvent } = {};
   const logIdQueue: string[] = [];
   let initializationTimeout: ReturnType<typeof setTimeout>;
   let isProcessingLogQueue = false;
@@ -504,8 +504,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function addKeyValueField(
     list: HTMLElement,
-    classes: {item: string; key: string; value: string; removeBtn: string},
-    placeholders: {key: string; value: string},
+    classes: { item: string; key: string; value: string; removeBtn: string },
+    placeholders: { key: string; value: string },
     removeLabel: string,
     key = '',
     value = '',
@@ -529,7 +529,7 @@ document.addEventListener('DOMContentLoaded', () => {
         value: 'header-value',
         removeBtn: 'remove-header-btn',
       },
-      {key: 'Header Name', value: 'Header Value'},
+      { key: 'Header Name', value: 'Header Value' },
       'Remove header',
       name,
       value,
@@ -545,13 +545,28 @@ document.addEventListener('DOMContentLoaded', () => {
         value: 'metadata-value',
         removeBtn: 'remove-metadata-btn',
       },
-      {key: 'Metadata Key', value: 'Metadata Value'},
+      { key: 'Metadata Key', value: 'Metadata Value' },
       'Remove metadata',
       key,
       value,
     );
   }
 
+  // Overload signatures
+  function getKeyValuePairs(
+    list: HTMLElement,
+    itemSelector: string,
+    keySelector: string,
+    valueSelector: string,
+    parseJson: true,
+  ): Record<string, any>;
+  function getKeyValuePairs(
+    list: HTMLElement,
+    itemSelector: string,
+    keySelector: string,
+    valueSelector: string,
+    parseJson?: false | undefined,
+  ): Record<string, string>;
   function getKeyValuePairs(
     list: HTMLElement,
     itemSelector: string,
@@ -728,7 +743,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const response = await fetch('/agent-card', {
         method: 'POST',
         headers: requestHeaders,
-        body: JSON.stringify({url: agentCardUrl, sid: socket.id}),
+        body: JSON.stringify({ url: agentCardUrl, sid: socket.id }),
       });
       const data = await response.json();
       if (!response.ok) {
@@ -994,7 +1009,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (p.text) {
       return DOMPurify.sanitize(marked.parse(p.text) as string);
     } else if (p.file) {
-      const {uri, bytes, mimeType} = p.file;
+      const { uri, bytes, mimeType } = p.file;
       if (bytes && mimeType) {
         return renderBase64Data(bytes, mimeType);
       } else if (uri && mimeType) {


### PR DESCRIPTION
# Description

Add support for Metadata parsing in the a2a inspector. Metadata is a map and should be parsed as such in the inspector. This adds support accordingly. 

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
