### PR TITLE
docs: move testing docs to contributors guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,3 +26,21 @@ Here are some additional things to keep in mind during the process:
 
 - **Test your changes.** Before you submit a pull request, make sure that your changes work as expected.
 - **Be patient.** It may take some time for your pull request to be reviewed and merged.
+
+## Testing
+
+Run all tests:
+
+```sh
+bash scripts/test.sh
+```
+
+Or run backend and frontend tests separately:
+
+```sh
+# Backend
+uv run pytest backend/tests/
+
+# Frontend
+cd frontend && npm test
+```

--- a/README.md
+++ b/README.md
@@ -133,28 +133,3 @@ The container is now running in the background. Open your web browser and naviga
 ### 4. Inspect your agents
 
 - Try inputting a sample agent URL such as `https://sample-a2a-agent-908687846511.us-central1.run.app`
-
-## Testing
-
-### Run all tests
-
-```sh
-# Make the script executable (first time only)
-chmod +x scripts/test.sh
-
-# Run all tests
-bash scripts/test.sh
-```
-
-### Run tests separately
-
-**Backend tests:**
-```sh
-uv run pytest backend/tests/
-```
-
-**Frontend tests:**
-```sh
-cd frontend
-npm test
-```


### PR DESCRIPTION
## Summary

Move testing documentation from README to CONTRIBUTING.md to better organize contributor-focused content.
