### PR TITLE
fix: use node:22-slim in Dockerfile to fix build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the frontend assets
-FROM node:18-alpine AS frontend-builder
+FROM node:22-slim AS frontend-builder
 WORKDIR /app
 
 # Copy package files and configuration needed for npm ci
@@ -12,10 +12,6 @@ RUN npm ci
 
 # Copy remaining files
 COPY frontend/ ./
-
-# Rebuild native dependencies like esbuild for the container's architecture (Alpine)
-# in case host node_modules were copied over.
-RUN npm rebuild esbuild
 
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- Switch Docker build stage from `node:18-alpine` to `node:22-slim` to fix container build failure
- Frontend dependencies (`marked@16`, `jsdom@27`, `vitest@4`, `vite@7`) require Node >= 20, causing `npm ci` to fail silently on Node 18
- Alpine's musl libc is incompatible with the glibc-only esbuild platform binaries in the lockfile, so `esbuild` is never installed
- Remove the now-unnecessary `npm rebuild esbuild` workaround

## Test plan
- [ ] Verify `podman build -t a2a-inspector .` completes successfully
- [ ] Verify the built container runs correctly (`podman run -p 8080:8080 a2a-inspector`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)