### PR TITLE
docs: clarify local backend startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ npm run build -- --watch
 cd backend
 
 # Run the FastAPI server with live reload
-uv run uvicorn app:app --host 127.0.0.1 --port 5001 --reload
+uv run -- uvicorn app:app --host 127.0.0.1 --port 5001 --reload
 ```
 
 ##### Access the Inspector

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ npm run build -- --watch
 cd backend
 
 # Run the FastAPI server with live reload
-uv run app.py
+uv run uvicorn app:app --host 127.0.0.1 --port 5001 --reload
 ```
 
 ##### Access the Inspector


### PR DESCRIPTION
## Summary
- update the README local backend startup command to use `uvicorn app:app`

## Why
This makes the backend host and port settings more explicit and makes host/port customization clearer for local users, without requiring them to edit `app.py`.

## Testing
- docs-only change
