### PR TITLE
fix: render data parts in message-kind agent responses

### DIFF
--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -1102,12 +1102,14 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         break;
       case 'message': {
-        const textPart = event.parts?.find(p => p.text);
-        if (textPart && textPart.text) {
-          const renderedContent = DOMPurify.sanitize(
-            marked.parse(textPart.text) as string,
-          );
-          const messageHtml = `<span class="kind-chip kind-chip-message">${event.kind}</span> ${renderedContent}`;
+        const allContent: string[] = [];
+        event.parts?.forEach(p => {
+          const content = processPart(p);
+          if (content) allContent.push(content);
+        });
+        if (allContent.length > 0) {
+          const combinedContent = allContent.join('');
+          const messageHtml = `<span class="kind-chip kind-chip-message">${event.kind}</span> ${combinedContent}`;
           appendMessage(
             'agent',
             messageHtml,


### PR DESCRIPTION
## Summary

Fixes #151

The `case 'message'` handler in the `agent_response` socket listener only rendered `text` parts. Responses containing `data` parts (structured JSON) were silently dropped — the message arrived in the inspector but nothing appeared in the chat window.

## Root Cause

```typescript
// Before — only finds text parts; data parts are ignored
const textPart = event.parts?.find(p => p.text);
if (textPart && textPart.text) {
  // render
}
```

## Fix

Replace the text-only lookup with a loop over all parts using the existing `processPart` helper, which already handles `text`, `data`, and `file` parts correctly:

```typescript
// After — renders all part types using the existing processPart helper
const allContent: string[] = [];
event.parts?.forEach(p => {
  const content = processPart(p);
  if (content) allContent.push(content);
});
if (allContent.length > 0) {
  const combinedContent = allContent.join('');
  const messageHtml = `<span class="kind-chip kind-chip-message">${event.kind}</span> ${combinedContent}`;
  appendMessage('agent', messageHtml, displayMessageId, true, validationErrors);
}
```

This is consistent with how `artifact-update` and `task` responses already handle parts.

## Test

Connect to an A2A v1.0 agent that uses the **immediate Message response** pattern (enqueues a `Message` with a `data` part rather than a `Task` with artifacts). Before this fix the chat window remained empty; after this fix the structured JSON is rendered in a `<pre><code>` block.

## Checklist

- [x] Bug fix (non-breaking change)
- [x] Existing text-part rendering still works (iterates all parts; `processPart` handles text correctly)
- [x] Data parts now render as formatted JSON consistent with artifact responses