### PR TITLE
fix: escape inspector JSON before rendering

### DIFF
--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -119,6 +119,25 @@ interface DebugLog {
   id: string;
 }
 
+export function escapeHtml(text: string): string {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function formatJsonForHtml(jsonData: unknown): string {
+  const json = JSON.stringify(jsonData, null, 2) ?? 'undefined';
+  const escaped = escapeHtml(json);
+  return escaped.replace(
+    /&quot;method&quot;: &quot;(.*?)&quot;/g,
+    (_match, method: string) =>
+      `<span class="json-highlight">&quot;method&quot;: &quot;${method}&quot;</span>`,
+  );
+}
+
 // Declare hljs global from CDN
 declare global {
   interface Window {
@@ -129,6 +148,10 @@ declare global {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  if (!document.getElementById('connect-btn')) {
+    return;
+  }
+
   const socket = io();
 
   const INITIALIZATION_TIMEOUT_MS = 10000;
@@ -731,12 +754,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const showJsonInModal = (jsonData: any) => {
     if (jsonData) {
-      let jsonString = JSON.stringify(jsonData, null, 2);
-      jsonString = jsonString.replace(
-        /"method": "([^"]+)"/g,
-        '<span class="json-highlight">"method": "$1"</span>',
-      );
-      modalJsonContent.innerHTML = jsonString;
+      modalJsonContent.innerHTML = formatJsonForHtml(jsonData);
       jsonModal.classList.remove('hidden');
     }
   };
@@ -812,14 +830,14 @@ document.addEventListener('DOMContentLoaded', () => {
       });
 
       if (data.validation_errors.length > 0) {
-        validationErrorsContainer.innerHTML = `<h3>Validation Errors</h3><ul>${data.validation_errors.map((e: string) => `<li>${e}</li>`).join('')}</ul>`;
+        validationErrorsContainer.innerHTML = `<h3>Validation Errors</h3><ul>${data.validation_errors.map((e: string) => `<li>${escapeHtml(e)}</li>`).join('')}</ul>`;
       } else {
         validationErrorsContainer.innerHTML =
           '<p class="success-text">Agent card is valid.</p>';
       }
     } catch (error) {
       clearTimeout(initializationTimeout);
-      validationErrorsContainer.innerHTML = `<p class="error-text">Error: ${(error as Error).message}</p>`;
+      validationErrorsContainer.innerHTML = `<p class="error-text">Error: ${escapeHtml((error as Error).message)}</p>`;
       chatInput.disabled = true;
       sendBtn.disabled = true;
     }
@@ -871,7 +889,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Enable attach button
         attachBtn.disabled = false;
       } else {
-        validationErrorsContainer.innerHTML = `<p class="error-text">Error initializing client: ${data.message}</p>`;
+        validationErrorsContainer.innerHTML = `<p class="error-text">Error initializing client: ${escapeHtml(data.message ?? '')}</p>`;
         isConnected = false;
         updateSessionUI();
       }
@@ -1253,19 +1271,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const logEntry = document.createElement('div');
     const timestamp = new Date().toLocaleTimeString();
 
-    let jsonString = JSON.stringify(log.data, null, 2);
-    jsonString = jsonString.replace(
-      /"method": "([^"]+)"/g,
-      '<span class="json-highlight">"method": "$1"</span>',
-    );
-
     logEntry.className = `log-entry log-${log.type}`;
     logEntry.innerHTML = `
             <div>
-                <span class="log-timestamp">${timestamp}</span>
-                <strong>${log.type.toUpperCase()}</strong>
+                <span class="log-timestamp">${escapeHtml(timestamp)}</span>
+                <strong>${escapeHtml(log.type.toUpperCase())}</strong>
             </div>
-            <pre>${jsonString}</pre>
+            <pre>${formatJsonForHtml(log.data)}</pre>
         `;
     debugContent.appendChild(logEntry);
 

--- a/frontend/tests/json-render.test.ts
+++ b/frontend/tests/json-render.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests that inspector JSON and validation errors are rendered as text,
+ * not interpreted as HTML.
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+
+vi.mock('socket.io-client', () => ({
+  io: () => ({
+    on: vi.fn(),
+    emit: vi.fn(),
+    id: 'test-sid',
+  }),
+}));
+
+import {escapeHtml, formatJsonForHtml} from '../src/script';
+
+describe('JSON HTML rendering', () => {
+  it('does not create an IMG node from a payload containing <img onerror>', () => {
+    const payload = {text: '<img src=x onerror=alert(1)>'};
+    const container = document.createElement('pre');
+    container.innerHTML = formatJsonForHtml(payload);
+
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.innerHTML).toContain(
+      '&lt;img src=x onerror=alert(1)&gt;',
+    );
+    expect(container.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+
+  it('does not create an IMG node from a validation error string', () => {
+    const error = 'Invalid text: "<img src=x onerror=alert(1)>"';
+    const container = document.createElement('div');
+    container.innerHTML = `<h3>Validation Errors</h3><ul><li>${escapeHtml(error)}</li></ul>`;
+
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+
+  it('does not create an IMG node when rendering a debug log entry', () => {
+    const payload = {text: '<img src=x onerror=alert(1)>'};
+    const logEntry = document.createElement('div');
+    logEntry.innerHTML = `
+            <div>
+                <span class="log-timestamp">${escapeHtml('12:00:00 PM')}</span>
+                <strong>${escapeHtml('RESPONSE')}</strong>
+            </div>
+            <pre>${formatJsonForHtml(payload)}</pre>
+        `;
+
+    expect(logEntry.querySelector('img')).toBeNull();
+    expect(logEntry.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+
+  it('highlights method names after escaping JSON', () => {
+    const payload = {
+      method: 'message/send',
+      text: '<img src=x onerror=alert(1)>',
+    };
+    const container = document.createElement('pre');
+    container.innerHTML = formatJsonForHtml(payload);
+
+    const highlight = container.querySelector('span.json-highlight');
+    expect(highlight).not.toBeNull();
+    expect(highlight?.textContent).toBe('"method": "message/send"');
+    expect(container.querySelector('img')).toBeNull();
+  });
+});


### PR DESCRIPTION
# Description

The inspector already runs chat text through DOMPurify. The debug console and the raw-JSON modal did not.

`showJsonInModal` and the `debug_log` handler did `JSON.stringify(...)` and assigned the result to `innerHTML`. `JSON.stringify` does not escape `<`, `>`, or `&`. A string field such as `"<img src=x onerror=alert(1)>"` became a real node if you opened Debug Console or clicked a message to view JSON. Validation errors from the backend were interpolated into `validationErrorsContainer.innerHTML` the same way, and those strings can include agent field values.

This only happens if you point the inspector at an agent that puts HTML in a payload and then open those views. Still worth closing: the chat path was already sanitized.

## What changed

In `frontend/src/script.ts`:

- `escapeHtml()` for text that goes into HTML.
- `formatJsonForHtml()` stringifies, escapes, then wraps the `"method"` highlight around the escaped text.
- `showJsonInModal`, the debug log `<pre>`, and the validation-error list use those helpers.

`frontend/tests/json-render.test.ts` feeds a payload with `<img onerror>` and checks that no `IMG` node is created, including when a method name is highlighted.

## How I tested

```
npm --prefix frontend test -- tests/json-render.test.ts
```

Four tests passed.
