### PR TITLE
fix: close client resources on re-initialization

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,5 @@
 import base64
+import inspect
 import logging
 
 from typing import Any
@@ -547,6 +548,26 @@ async def get_agent_card(request: Request) -> JSONResponse:
 # ==============================================================================
 
 
+async def _release_client(sid: str) -> None:
+    """Close and drop any stored client for sid, ignoring close errors."""
+    existing = clients.pop(sid, None)
+    if existing is None:
+        return
+    httpx_client, a2a_client, _, _ = existing
+    closer = getattr(a2a_client, 'close', None)
+    if callable(closer):
+        try:
+            result = closer()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.debug(f'Error closing A2A client for {sid}', exc_info=True)
+    try:
+        await httpx_client.aclose()
+    except Exception:
+        logger.debug(f'Error closing httpx client for {sid}', exc_info=True)
+
+
 @sio.on('connect')
 async def handle_connect(sid: str, environ: dict[str, Any]) -> None:
     """Handle the 'connect' socket.io event."""
@@ -558,8 +579,7 @@ async def handle_disconnect(sid: str) -> None:
     """Handle the 'disconnect' socket.io event."""
     logger.info(f'Client disconnected: {sid}')
     if sid in clients:
-        httpx_client, _, _, _ = clients.pop(sid)
-        await httpx_client.aclose()
+        await _release_client(sid)
         logger.info(f'Cleaned up client for {sid}')
 
 
@@ -591,6 +611,7 @@ async def handle_initialize_client(sid: str, data: dict[str, Any]) -> None:
         a2a_client = factory.create(card)
         transport_protocol = _get_transport_from_card(card)
 
+        await _release_client(sid)
         clients[sid] = (httpx_client, a2a_client, card, transport_protocol)
 
         input_modes = _get_input_modes(card)

--- a/backend/tests/test_app_clients.py
+++ b/backend/tests/test_app_clients.py
@@ -1,0 +1,125 @@
+"""Regression tests for per-sid httpx/A2A client lifecycle."""
+
+import contextlib
+import sys
+
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# app.py is started from backend/ (`import validators`, relative static paths).
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+with contextlib.chdir(_BACKEND_DIR):
+    from backend import app as app_module
+
+
+def _mock_card() -> MagicMock:
+    card = MagicMock()
+    card.supported_interfaces = None
+    card.preferred_transport = None
+    card.default_input_modes = ['text/plain']
+    card.default_output_modes = ['text/plain']
+    return card
+
+
+@pytest.fixture
+def init_client_mocks() -> Iterator[tuple[list[AsyncMock], list[AsyncMock]]]:
+    resolver = MagicMock()
+    resolver.get_agent_card = AsyncMock(return_value=_mock_card())
+
+    a2a_clients: list[AsyncMock] = []
+
+    def create_a2a(_card: object) -> AsyncMock:
+        client = AsyncMock()
+        a2a_clients.append(client)
+        return client
+
+    factory = MagicMock()
+    factory.create.side_effect = create_a2a
+
+    httpx_clients = [AsyncMock(), AsyncMock()]
+    httpx_iter = iter(httpx_clients)
+
+    with (
+        patch.object(app_module, 'A2ACardResolver', return_value=resolver),
+        patch.object(app_module, 'ClientFactory', return_value=factory),
+        patch.object(
+            app_module.httpx,
+            'AsyncClient',
+            side_effect=lambda **_kwargs: next(httpx_iter),
+        ),
+        patch.object(app_module.sio, 'emit', new_callable=AsyncMock),
+    ):
+        yield httpx_clients, a2a_clients
+
+
+@pytest.mark.asyncio
+async def test_reinitialize_closes_previous_httpx_client(
+    init_client_mocks: tuple[list[AsyncMock], list[AsyncMock]],
+) -> None:
+    httpx_clients, a2a_clients = init_client_mocks
+    sid = 'sid-reinit'
+    app_module.clients.pop(sid, None)
+    try:
+        await app_module.handle_initialize_client(
+            sid, {'url': 'https://agent-a.example/card'}
+        )
+        await app_module.handle_initialize_client(
+            sid, {'url': 'https://agent-b.example/card'}
+        )
+
+        httpx_clients[0].aclose.assert_awaited_once()
+        a2a_clients[0].close.assert_awaited_once()
+        httpx_clients[1].aclose.assert_not_awaited()
+        assert app_module.clients[sid][0] is httpx_clients[1]
+        assert app_module.clients[sid][1] is a2a_clients[1]
+    finally:
+        app_module.clients.pop(sid, None)
+
+
+@pytest.mark.asyncio
+async def test_reinitialize_swallows_previous_close_errors(
+    init_client_mocks: tuple[list[AsyncMock], list[AsyncMock]],
+) -> None:
+    httpx_clients, a2a_clients = init_client_mocks
+    sid = 'sid-reinit-error'
+    app_module.clients.pop(sid, None)
+    try:
+        await app_module.handle_initialize_client(
+            sid, {'url': 'https://agent-a.example/card'}
+        )
+        a2a_clients[0].close.side_effect = RuntimeError('a2a close failed')
+        httpx_clients[0].aclose.side_effect = RuntimeError('httpx close failed')
+
+        await app_module.handle_initialize_client(
+            sid, {'url': 'https://agent-b.example/card'}
+        )
+
+        httpx_clients[0].aclose.assert_awaited_once()
+        assert app_module.clients[sid][0] is httpx_clients[1]
+    finally:
+        app_module.clients.pop(sid, None)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_closes_stored_client() -> None:
+    sid = 'sid-disconnect'
+    httpx_client = AsyncMock()
+    a2a_client = AsyncMock()
+    app_module.clients[sid] = (
+        httpx_client,
+        a2a_client,
+        MagicMock(),
+        'JSONRPC',
+    )
+
+    await app_module.handle_disconnect(sid)
+
+    a2a_client.close.assert_awaited_once()
+    httpx_client.aclose.assert_awaited_once()
+    assert sid not in app_module.clients


### PR DESCRIPTION
## Summary

Re-initializing a Socket.IO client replaced the entry in `backend/app.py`'s `clients` map without closing the previous HTTPX connection pool. Repeated connections under the same session ID could therefore leave idle sockets open until process exit.

This adds `_release_client`, which removes the stored entry and closes both the A2A client and its `httpx.AsyncClient`. `handle_initialize_client` now calls it immediately before storing a successfully created replacement, while `handle_disconnect` uses the same cleanup path. Close failures are logged and do not prevent initialization.

Regression coverage in `backend/tests/test_app_clients.py` verifies replacement cleanup, cleanup-error handling, and disconnect cleanup.

## Testing

`uv run pytest backend/tests/test_app_clients.py -v`

`git diff --check`
